### PR TITLE
[FIX] formatParams expects string

### DIFF
--- a/pkg/server/routes/web/index.go
+++ b/pkg/server/routes/web/index.go
@@ -120,9 +120,9 @@ func sanitizeParams(jobs []model.SyncJob) error {
 	return nil
 }
 
-func formatParams(paramsData []byte) (string, error) {
+func formatParams(paramsData string) (string, error) {
 	params := make(map[string]string)
-	err := json.Unmarshal(paramsData, &params)
+	err := json.Unmarshal([]byte(paramsData), &params)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
formatParams() is only used in the frontend where the parameter is a string.